### PR TITLE
Update to a more recent Kubernetes version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ## Really cheap Kubernetes cluster on AWS with kubeadm
 
-**This repo was forked from https://github.com/cablespaghetti/kubeadm-aws.  It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**
+**This repo was forked from https://github.com/edtan/kubeadm-aws (originally https://github.com/cablespaghetti/kubeadm-aws). I've got it running, and I intend to bring it up to date slowly.
+Prior to latest fork: It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**
 
 This repository contains a bunch of Bash and Terraform code which provisions what I believe to be the cheapest possible single master Kubernetes cluster on AWS. You can run a 1 master, 1 worker cluster for somewhere around $6 a month, or just the master node (which can also run pods) for around $3 a month.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Added feature to allow you to set the EBS volume type that the instances boot fr
 
 Also note, there is a workaround Ed Tan added to the master node startup to switch CPU credits from UNLIMITED to STANDARD; the ticket below is CLOSED and I'm unsure if TF actually fixed the issue.
 
-Code works, but still some work to do -- but I'm hoping to push out a 0.22 release which is still somehat supported.
+Code (still) works, but doing some work to do -- but I'm hoping to push out a 0.22 release which is still somehat supported.
 
 **Prior to latest fork:
 It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-## Really cheap Kubernetes cluster on AWS with kubeadm
+## Inexpensive Kubernetes cluster on AWS with kubeadm
 
 **This repo was forked from https://github.com/edtan/kubeadm-aws (originally https://github.com/cablespaghetti/kubeadm-aws). I've got it running, and I intend to bring it up to date slowly.
-Prior to latest fork: It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**
+Prior to latest fork:
+It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**
 
 This repository contains a bunch of Bash and Terraform code which provisions what I believe to be the cheapest possible single master Kubernetes cluster on AWS. You can run a 1 master, 1 worker cluster for somewhere around $6 a month, or just the master node (which can also run pods) for around $3 a month.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
 ## Inexpensive Kubernetes cluster on AWS with kubeadm
 
-**This repo was forked from https://github.com/edtan/kubeadm-aws (originally https://github.com/cablespaghetti/kubeadm-aws). I've got it running, and I intend to bring it up to date slowly.
-Prior to latest fork:
+**This repo was forked from https://github.com/edtan/kubeadm-aws (originally https://github.com/cablespaghetti/kubeadm-aws).
+I'm currently running 1.21.12 as an upgrade from the below 1.18.0 version of Kubernetes.
+Added feature to allow you to set the EBS volume type that the instances boot from.
+
+Also note, there is a workaround Ed Tan added to the master node startup to switch CPU credits from UNLIMITED to STANDARD; the ticket below is CLOSED and I'm unsure if TF actually fixed the issue.
+
+Code works, but still some work to do -- but I'm hoping to push out a 0.22 release which is still somehat supported.
+
+**Prior to latest fork:
 It has been updated to use burstable a t3.small for the control plane node, and t3.micros for the workers.  Kubernetes has been updated from 1.13.4 to 1.18.0, Flannel has been changed to Calico, Helm has been updated from v2 to v3, and the Terraform files have been updated to 0.12 syntax.  There is currently a known bug where the t3.small runs as using unlimited CPU credits - see https://github.com/terraform-providers/terraform-provider-aws/issues/6109**
 
 This repository contains a bunch of Bash and Terraform code which provisions what I believe to be the cheapest possible single master Kubernetes cluster on AWS. You can run a 1 master, 1 worker cluster for somewhere around $6 a month, or just the master node (which can also run pods) for around $3 a month.

--- a/main.tf
+++ b/main.tf
@@ -536,6 +536,10 @@ resource "aws_spot_instance_request" "master" {
   wait_for_fulfillment   = true
   private_ip             = "10.0.100.4"
 
+  root_block_device {
+    volume_type = var.root-volume-type
+  }
+
   credit_specification {
     cpu_credits = "standard"
   }

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,11 @@ variable "master-spot-price" {
   description = "The maximum spot bid for the master node"
 }
 
+variable "root-volume-type" {
+  default     = "gp2"
+  description = "The type of EBS volume for the root device, eg standard/gp2/gp3 etc"
+}
+
 variable "worker-instance-type" {
   default     = "t3.micro"
   description = "Which EC2 instance type to use for the worker nodes"

--- a/variables.tf
+++ b/variables.tf
@@ -69,7 +69,7 @@ variable "az" {
 }
 
 variable "kubernetes-version" {
-  default     = "1.18.0"
+  default     = "1.21.12"
   description = "Which version of Kubernetes to install"
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,7 @@
 
 terraform {
   required_version = ">= 0.12"
+   required_providers {
+     aws = "~> 3.73.0"
+   }
 }


### PR DESCRIPTION
I've done some minor tweaks to bring the version forward and expose the boot EBS volume to be able to pick different types (gp3, standard, etc)